### PR TITLE
Clips lower end of data used to create trendline

### DIFF
--- a/qal/rta/data_visualizer/well_data_plotter.py
+++ b/qal/rta/data_visualizer/well_data_plotter.py
@@ -253,7 +253,7 @@ class WellPlotter:
         y_data = df_plot[col_to_plot].values
         cnr_data = df_plot['CNR'].values
         if graph_type == 'concentration':
-            x_at_good_cnr = x_data[cnr_data > 3]
+            x_at_good_cnr = x_data[cnr_data >= 3]
             linear_min = np.min(x_at_good_cnr)
             linear_min_idx = np.where(x_data == linear_min)[0][0]
             x_hat = np.geomspace(x_data[linear_min_idx], np.max(x_data), 100)

--- a/qal/rta/data_visualizer/well_data_plotter.py
+++ b/qal/rta/data_visualizer/well_data_plotter.py
@@ -253,10 +253,12 @@ class WellPlotter:
         y_data = df_plot[col_to_plot].values
         cnr_data = df_plot['CNR'].values
         if graph_type == 'concentration':
-            linear_min_idx = np.argmin(np.abs(cnr_data - 3))
-            if cnr_data[linear_min_idx] < 3:
-                linear_min_idx -= 1
+            x_at_good_cnr = x_data[cnr_data > 3]
+            linear_min = np.min(x_at_good_cnr)
+            linear_min_idx = np.where(x_data == linear_min)[0][0]
             x_hat = np.geomspace(x_data[linear_min_idx], np.max(x_data), 100)
+            x_data = x_data[linear_min_idx::-1]
+            y_data = y_data[linear_min_idx::-1]
         else:
             x_hat = np.linspace(np.min(x_data), np.max(x_data), 100)
         self.add_trendline_and_annotation(fit_type, x_data, y_data, x_hat, library=trendline_lib, graph_type=graph_type)


### PR DESCRIPTION
This pull request addresses the issue raised in #18, where the trendline for RCS analysis is generated from the entire data range but displayed for CNR > 3. Now the trendline is fit for data points with CNR > 3. An example of the difference this makes is shown below. Analysis was performed on the same image of an RCS target. In the first case using the current code, the 1 nM well, which has CNR < 3, is included in generating the trendline. However, the trendline is shown for 3 nM and above. The value of the exponent in the equation is 0.936:

![V1-70Q-ST01-RCS008_linearity_pre](https://github.com/user-attachments/assets/82c34148-eb64-4f1e-83fb-c5b43f997cc0)

With this update, the 1 nM is not included in generating the trendline (because it has CNR < 3). The value of the exponent in the equation is 0.956:

![V1-70Q-ST01-RCS008_linearity](https://github.com/user-attachments/assets/ead3f033-fe62-45c7-a6b7-cb4ba47bda00)
