### PR TITLE
Bugfix for WellDetector over-filtering

### DIFF
--- a/qal/rta/data_visualizer/well_data_plotter.py
+++ b/qal/rta/data_visualizer/well_data_plotter.py
@@ -253,7 +253,7 @@ class WellPlotter:
         y_data = df_plot[col_to_plot].values
         cnr_data = df_plot['CNR'].values
         if graph_type == 'concentration':
-            x_at_good_cnr = x_data[cnr_data > 3]
+            x_at_good_cnr = x_data[cnr_data >= 3]
             linear_min = np.min(x_at_good_cnr)
             linear_min_idx = np.where(x_data == linear_min)[0][0]
             x_hat = np.geomspace(x_data[linear_min_idx], np.max(x_data), 100)

--- a/qal/rta/data_visualizer/well_data_plotter.py
+++ b/qal/rta/data_visualizer/well_data_plotter.py
@@ -253,10 +253,12 @@ class WellPlotter:
         y_data = df_plot[col_to_plot].values
         cnr_data = df_plot['CNR'].values
         if graph_type == 'concentration':
-            linear_min_idx = np.argmin(np.abs(cnr_data - 3))
-            if cnr_data[linear_min_idx] < 3:
-                linear_min_idx -= 1
+            x_at_good_cnr = x_data[cnr_data > 3]
+            linear_min = np.min(x_at_good_cnr)
+            linear_min_idx = np.where(x_data == linear_min)[0][0]
             x_hat = np.geomspace(x_data[linear_min_idx], np.max(x_data), 100)
+            x_data = x_data[linear_min_idx::-1]
+            y_data = y_data[linear_min_idx::-1]
         else:
             x_hat = np.linspace(np.min(x_data), np.max(x_data), 100)
         self.add_trendline_and_annotation(fit_type, x_data, y_data, x_hat, library=trendline_lib, graph_type=graph_type)

--- a/qal/rta/roi_extraction/well_detector.py
+++ b/qal/rta/roi_extraction/well_detector.py
@@ -167,7 +167,6 @@ class WellDetector:
                 mask = abs(df['ROI Radius'] - mean_radius) > threshold
             # Remove those rows
             df_filtered = df[~mask]
-            print(df_filtered)
 
             return df_filtered
 


### PR DESCRIPTION
This updates fixes the bug reported in #21. Because the threshold value used was chosen from working with a lot of images, it will not be changed for now. Instead, a check will be run after the `get_clusters_from_points()` method, and if the data frame is empty or has less than 3 identified wells, the method will be rerun using a different value based on the standard deviation of identified ROI radii as the threshold. An example of this fix is shown below by calling `detect_wells()` with `show_detected_wells=True`. In the first case, all but one well were filtered out, but after rerunning, 8 wells are displayed. Rerunning `get_clusters_from_points()` does not significantly increase processing time.

![image](https://github.com/user-attachments/assets/39d4efb2-45b9-4c0a-8152-87bdbdb33887)

Potentially in the future, we might consider updating the default threshold.