### PR TITLE
Adjustable CNR threshold

### DIFF
--- a/qal/rta/data_visualizer/well_data_plotter.py
+++ b/qal/rta/data_visualizer/well_data_plotter.py
@@ -255,11 +255,15 @@ class WellPlotter:
         cnr_data = df_plot['CNR'].values
         if graph_type == 'concentration':
             x_at_good_cnr = x_data[cnr_data >= cnr_threshold]
-            linear_min = np.min(x_at_good_cnr)
-            linear_min_idx = np.where(x_data == linear_min)[0][0]
-            x_hat = np.geomspace(x_data[linear_min_idx], np.max(x_data), 100)
-            x_data = x_data[linear_min_idx::-1]
-            y_data = y_data[linear_min_idx::-1]
+            if not x_at_good_cnr:
+                x_data = []
+                y_data = []
+            else:
+                linear_min = np.min(x_at_good_cnr)
+                linear_min_idx = np.where(x_data == linear_min)[0][0]
+                x_hat = np.geomspace(x_data[linear_min_idx], np.max(x_data), 100)
+                x_data = x_data[linear_min_idx::-1]
+                y_data = y_data[linear_min_idx::-1]
         else:
             x_hat = np.linspace(np.min(x_data), np.max(x_data), 100)
         if len(x_data) > 1:

--- a/qal/rta/data_visualizer/well_data_plotter.py
+++ b/qal/rta/data_visualizer/well_data_plotter.py
@@ -255,7 +255,7 @@ class WellPlotter:
         cnr_data = df_plot['CNR'].values
         if graph_type == 'concentration':
             x_at_good_cnr = x_data[cnr_data >= cnr_threshold]
-            if not x_at_good_cnr:
+            if x_at_good_cnr.size == 0:
                 x_data = []
                 y_data = []
             else:

--- a/qal/rta/data_visualizer/well_data_plotter.py
+++ b/qal/rta/data_visualizer/well_data_plotter.py
@@ -262,7 +262,10 @@ class WellPlotter:
             y_data = y_data[linear_min_idx::-1]
         else:
             x_hat = np.linspace(np.min(x_data), np.max(x_data), 100)
-        self.add_trendline_and_annotation(fit_type, x_data, y_data, x_hat, library=trendline_lib, graph_type=graph_type)
+        if len(x_data) > 1:
+            self.add_trendline_and_annotation(fit_type, x_data, y_data, x_hat, library=trendline_lib, graph_type=graph_type)
+        else:
+            print(f"Unable to generate trendline. CNR threshold of {cnr_threshold} is too high.")
         if graph_type == 'depth':
             self.add_depth_detection_limit(fit_type, x_data, cnr_data, x_hat, cnr_threshold, library=trendline_lib)
 


### PR DESCRIPTION
This change introduces the option to adjust the CNR threshold used in displaying linearity for RCS analysis, and depth sensitivity for RDS analysis. The recommended value from TG-311 is CNR = 3, however, some users may want to adjust. The change is implemented in `WellPlotter`. To plot linearity for an RCS target using 1.2 as the CNR threshold:
```python
plotter = WellPlotter(df, image)
plotter.plot(
    graph_type='concentration',
    col_to_plot='mean intensity normalized',
    plot_error_bars=False,
    save_plot=None,
    cnr_threshold=1.2
)
```